### PR TITLE
feat: verify first, check semantics after and remove issuanceDate check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 package-lock.json
 .nyc_output
 dist
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,7 @@ async function verify(options = {}) {
     return await _verifyPresentation(options);
   } catch(error) {
     if(error instanceof TypeError) {
-      throw error
+      throw error;
     }
     return {
       verified: false,
@@ -258,7 +258,7 @@ async function verifyCredential(options = {}) {
     return await _verifyCredential(options);
   } catch(error) {
     if(error instanceof TypeError) {
-      throw error
+      throw error;
     }
     return {
       verified: false,
@@ -292,20 +292,10 @@ async function verifyCredential(options = {}) {
 async function _verifyCredential(options = {}) {
   const {credential, checkStatus, now} = options;
 
-  // Fine grained result log containing checks performed. Example:
+  // Fine-grained result log containing checks performed. Example:
   // [{id: 'valid_signature', valid: true},
   //  {id: 'expiration', valid: true}]
   const log = [];
-
-  // run common credential checks (add check results to log)
-  _checkCredential({credential, log, now});
-
-  // if credential status is provided, a `checkStatus` function must be given
-  if(credential.credentialStatus && typeof options.checkStatus !== 'function') {
-    throw new TypeError(
-      'A "checkStatus" function must be given to verify credentials with ' +
-      '"credentialStatus".');
-  }
 
   const documentLoader = options.documentLoader || defaultDocumentLoader;
 
@@ -327,6 +317,16 @@ async function _verifyCredential(options = {}) {
   // if verification has already failed, skip status check
   if(!result.verified) {
     return result;
+  }
+
+  // run common credential checks (add check results to log)
+  _checkCredential({credential, log, now});
+
+  // if credential status is provided, a `checkStatus` function must be given
+  if(credential.credentialStatus && typeof options.checkStatus !== 'function') {
+    throw new TypeError(
+      'A "checkStatus" function must be given to verify credentials with ' +
+      '"credentialStatus".');
   }
 
   log.push({id: 'valid_signature', valid: true});
@@ -468,12 +468,21 @@ async function signPresentation(options = {}) {
 async function _verifyPresentation(options = {}) {
   const {presentation, unsignedPresentation} = options;
 
-  _checkPresentation(presentation);
-
   const documentLoader = options.documentLoader || defaultDocumentLoader;
 
-  // FIXME: verify presentation first, then each individual credential
-  // only if that proof is verified
+  const {controller, domain, challenge} = options;
+  if(!options.presentationPurpose && !challenge) {
+    throw new Error(
+      'A "challenge" param is required for AuthenticationProofPurpose.');
+  }
+
+  const purpose = options.presentationPurpose ||
+    new AuthenticationProofPurpose({controller, domain, challenge});
+
+  const presentationResult = await jsigs.verify(
+    presentation, {purpose, documentLoader, ...options});
+
+  _checkPresentation(presentation);
 
   // if verifiableCredentials are present, verify them, individually
   let credentialResults;
@@ -499,18 +508,6 @@ async function _verifyPresentation(options = {}) {
     // No need to verify the proof section of this presentation
     return {verified, results: [presentation], credentialResults};
   }
-
-  const {controller, domain, challenge} = options;
-  if(!options.presentationPurpose && !challenge) {
-    throw new Error(
-      'A "challenge" param is required for AuthenticationProofPurpose.');
-  }
-
-  const purpose = options.presentationPurpose ||
-    new AuthenticationProofPurpose({controller, domain, challenge});
-
-  const presentationResult = await jsigs.verify(
-    presentation, {purpose, documentLoader, ...options});
 
   return {
     presentationResult,
@@ -621,16 +618,9 @@ function _checkCredential({credential, log = [], now = new Date()}) {
   }
 
   if('issuanceDate' in credential) {
-    let {issuanceDate} = credential;
+    const {issuanceDate} = credential;
     if(!dateRegex.test(issuanceDate)) {
       throw new Error(`"issuanceDate" must be a valid date: ${issuanceDate}`);
-    }
-    // check if `now` is before `issuanceDate`
-    issuanceDate = new Date(issuanceDate);
-    if(now < issuanceDate) {
-      throw new Error(
-        `The current date time (${now.toISOString()}) is before the ` +
-        `"issuanceDate" (${issuanceDate.toISOString()}).`);
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,8 +152,9 @@ async function issue({
     credential.issuanceDate = `${now.substr(0, now.length - 5)}Z`;
   }
 
-  // run common credential checks
-  _checkCredential({credential, now});
+  // run common credential checks but skip issuance and expiration checks
+  // as the issuer chooses them.
+  _checkCredential({credential, now, dateVerification: false});
 
   return jsigs.sign(credential, {purpose, documentLoader, suite, expansionMap});
 }
@@ -569,10 +570,18 @@ function _checkPresentation(presentation) {
  *   verification result reporting.
  * @param {string|Date} [options.now] - A string representing date time in
  *   ISO 8601 format or an instance of Date. Defaults to current date time.
+ * @param {Boolean} [options.dateVerification] - A boolean if the credential
+ *   should also be checked for issuance and expiration dates.
+ *   In verification flows this should be done. In issuance flows not.
  * @throws {Error}
  * @private
  */
-function _checkCredential({credential, log = [], now = new Date()}) {
+function _checkCredential({
+  credential,
+  log = [],
+  now = new Date(),
+  dateVerification = true
+}) {
   if(typeof now === 'string') {
     now = new Date(now);
   }
@@ -618,9 +627,18 @@ function _checkCredential({credential, log = [], now = new Date()}) {
   }
 
   if('issuanceDate' in credential) {
-    const {issuanceDate} = credential;
+    let {issuanceDate} = credential;
     if(!dateRegex.test(issuanceDate)) {
       throw new Error(`"issuanceDate" must be a valid date: ${issuanceDate}`);
+    }
+    if(dateVerification) {
+      // check if `now` is before `issuanceDate`
+      issuanceDate = new Date(issuanceDate);
+      if(now < issuanceDate) {
+        throw new Error(
+          `The current date time (${now.toISOString()}) is before the ` +
+          `"issuanceDate" (${issuanceDate.toISOString()}).`);
+      }
     }
   }
 
@@ -665,12 +683,14 @@ function _checkCredential({credential, log = [], now = new Date()}) {
       error.log = log;
       throw error;
     }
-    // check if `now` is after `expirationDate`
-    if(now > new Date(expirationDate)) {
-      log.push({id: 'expiration', valid: false});
-      const error = new Error('Credential has expired.');
-      error.log = log;
-      throw error;
+    if(dateVerification) {
+      // check if `now` is after `expirationDate`
+      if(now > new Date(expirationDate)) {
+        log.push({id: 'expiration', valid: false});
+        const error = new Error('Credential has expired.');
+        error.log = log;
+        throw error;
+      }
     }
   }
   log.push({id: 'expiration', valid: true});

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -497,24 +497,6 @@ describe('_checkCredential', () => {
     error.message.should
       .contain('Credential has expired.');
   });
-
-  it('should reject if "now" is before "issuanceDate"', () => {
-    const credential = jsonld.clone(mockData.credentials.alpha);
-    credential.issuer = 'did:example:12345';
-    credential.issuanceDate = '2022-10-31T19:21:25Z';
-    const now = '2022-06-30T19:21:25Z';
-    let error;
-    try {
-      vc._checkCredential({credential, now});
-    } catch(e) {
-      error = e;
-    }
-    should.exist(error,
-      'Should throw error when "now" is before "issuanceDate"');
-    error.message.should.contain(
-      'The current date time (2022-06-30T19:21:25.000Z) is before the ' +
-      '"issuanceDate" (2022-10-31T19:21:25.000Z).');
-  });
 });
 
 async function _generateCredential() {


### PR DESCRIPTION
This PR proposes the some changes as discussed in: https://github.com/digitalcredentials/vc/issues/7

- Verify Presenation Proof & Credential Proof **_FIRST_** **before** doing any semantic checks as the fields may be tampered with. 
- Remove check if issuanceDate is not in the future as this is a fully expected use-case (to issue credentials that become valid at some point in time)

IMHO we should also remove the check (if not even all of them) if a credential is expired when issuing it. For some e2e test scenarios one may choose to issue an expired credential.

I am still a bit confused. Initally my PR was larger, with more modifications to error handling as well. But it seems jsigs already does alot of sanity and semantic checks on the credential (checking if a context is there for example). Is there a reason we do them again here?