### PR TITLE
Update to latest jsonld, jsigs, sig2020.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalcredentials/vc ChangeLog
 
+## v7.x
+- "@digitalcredentials/ed25519-signature-2020": "digitalcredentials/ed25519-signature-2020#v4.x",
+- "@digitalcredentials/jsonld": "digitalcredentials/jsonld.js#update",
+- "@digitalcredentials/jsonld-signatures": "digitalcredentials/jsonld-signatures#v10.x",
+
 ## 6.0.1 - 2024-01-23
 ### Changed
 - Update to use latest OBv3 context in tests

--- a/lib/CredentialIssuancePurpose.js
+++ b/lib/CredentialIssuancePurpose.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
-const jsonld = require('@digitalcredentials/jsonld');
+const jsonld = require('jsonld');
 const {AssertionProofPurpose} =
   require('@digitalcredentials/jsonld-signatures').purposes;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@
  */
 'use strict';
 
-const jsonld = require('@digitalcredentials/jsonld');
+const jsonld = require('jsonld');
 const jsigs = require('@digitalcredentials/jsonld-signatures');
 const {AuthenticationProofPurpose} = jsigs.purposes;
 const CredentialIssuancePurpose = require('./CredentialIssuancePurpose');

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalbazaar/vc-status-list": "^7.0.0",
-    "@digitalcredentials/ed25519-signature-2020": "^3.0.2",
-    "@digitalcredentials/jsonld": "^6.0.0",
-    "@digitalcredentials/jsonld-signatures": "^9.3.2",
+    "@digitalcredentials/ed25519-signature-2020": "^4.0.0",
+    "jsonld": "digitalcredentials/jsonld.js#v10.x",
+    "@digitalcredentials/jsonld-signatures": "^10.0.1",
     "@digitalcredentials/open-badges-context": "^2.1.0",
-    "@digitalcredentials/vc-status-list": "^5.0.2",
     "credentials-context": "^2.0.0",
     "fix-esm": "^1.0.1"
   },
@@ -31,6 +29,7 @@
     "@digitalbazaar/ed25519-signature-2018": "^2.0.1",
     "@digitalbazaar/ed25519-verification-key-2018": "^3.0.0",
     "@digitalcredentials/security-document-loader": "^3.2.0",
+    "@digitalcredentials/vc-status-list": "^5.0.2",
     "babel-loader": "^8.2.2",
     "chai": "^4.3.3",
     "cross-env": "^7.0.3",

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -7,7 +7,7 @@ const should = chai.should();
 const {Ed25519VerificationKey2018} =
   require('@digitalbazaar/ed25519-verification-key-2018');
 const jsigs = require('@digitalcredentials/jsonld-signatures');
-const jsonld = require('@digitalcredentials/jsonld');
+const jsonld = require('jsonld');
 const {Ed25519Signature2018} = require('@digitalbazaar/ed25519-signature-2018');
 const {Ed25519Signature2020} =
   require('@digitalcredentials/ed25519-signature-2020');


### PR DESCRIPTION
* Switch to DigitalBazaar's `jsonld`, `http-client` and `rdf-canonize` libs
* Switch to Sphereon's fork of `isomorphic-webcrypto`
* Partly addresses issue https://github.com/digitalcredentials/jsonld-signatures/issues/5