### PR TITLE
move signature log entries before expiry check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalcredentials/vc ChangeLog
 
+## 9.0.0 - 2024-09-30
+
+### Fixed
+- add signature checks to the log before running other verification checks whose errors might prevent that logging
+
 ## 9.0.0 - 2024-09-17
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -352,6 +352,9 @@ async function _verifyCredential(options = {}) {
     }
   }
 
+  log.push({id: 'valid_signature', valid: true});
+  log.push({id: 'issuer_did_resolves', valid: true});
+
   // run common credential checks (add check results to log)
   _checkCredential({credential, log, now});
 
@@ -361,9 +364,6 @@ async function _verifyCredential(options = {}) {
       'A "checkStatus" function must be given to verify credentials with ' +
       '"credentialStatus".');
   }
-
-  log.push({id: 'valid_signature', valid: true});
-  log.push({id: 'issuer_did_resolves', valid: true});
 
   if(credential.credentialStatus) {
     await addStatusInfoToLog({options, result, log});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/vc",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Verifiable Credentials JavaScript library.",
   "homepage": "https://github.com/digitalcredentials/vc",
   "repository": {


### PR DESCRIPTION
Moves the two log entries for the signature check to before the expiry check (the expiry check happens in _checkCredential({credential, log, now})).

That way a successful signature check gets logged even if the expiry check fails. Otherwise, a failing expiry check throws an error which interrupts execution before it adds the log entries for the signature check.